### PR TITLE
add TCP enablement, mixed mode auth, SQL/AD logins, impersonation, linked servers, and xp_cmdshell support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ansible Role: MSSQL
 
-An Ansible role that installs [MSSQL](https://learn.microsoft.com/en-us/sql/sql-server/?view=sql-server-ver16) on Windows systems.
+An Ansible role that installs [MSSQL](https://learn.microsoft.com/en-us/sql/sql-server/?view=sql-server-ver16) on Windows systems with support for TCP enablement, mixed mode authentication, SQL and AD logins, linked servers, impersonation, and xp_cmdshell configuration.
 
 ## Requirements
 
@@ -10,7 +10,7 @@ None
 
 Available variables are listed below, along with default values (see `defaults/main.yml`):
 
-    ludus_mssql_version: "2019"
+    # General
     ludus_install_directory: /opt/ludus
     ludus_mssql_iso_directory: "C:\\ludus"
     # Valid ludus_mssql_version options are "2019" or "2022"
@@ -22,6 +22,49 @@ Available variables are listed below, along with default values (see `defaults/m
     ludus_mssql_sql_license_key:
     ludus_mssql_ssms_url: "https://aka.ms/ssmsfullsetup"
     ludus_mssql_install_ssms: true
+    # Enable TCP/IP protocol and open Windows Firewall port 1433 (default: false)
+    ludus_mssql_enable_tcp: true
+    # Enable SQL Server mixed mode authentication (Windows + SQL logins) (default: false)
+    ludus_mssql_mixed_mode_auth: false
+    # Enable xp_cmdshell (default: false)
+    ludus_mssql_enable_xp_cmdshell: false
+
+    # SQL logins to create (requires ludus_mssql_mixed_mode_auth: true)
+    ludus_mssql_sql_users: []
+    # Example:
+    # ludus_mssql_sql_users:
+    #   - username: "sqladmin"
+    #     password: "Password123!"
+    #     sysadmin: true
+    #   - username: "appuser"
+    #     password: "Password123!"
+    #     sysadmin: false
+
+    # Active Directory Windows logins to create
+    ludus_mssql_ad_logins: []
+    # Example:
+    # ludus_mssql_ad_logins:
+    #   - username: "domain\\jsmith"
+    #     sysadmin: false
+    #   - username: "domain\\user"
+    #     sysadmin: true
+
+    # Impersonation grants between logins
+    ludus_mssql_impersonations: []
+    # Example:
+    # ludus_mssql_impersonations:
+    #   - grantor: "sqladmin"
+    #     grantee: "appuser"
+
+    # Linked servers to configure
+    ludus_mssql_linked_servers: []
+    # Example:
+    # ludus_mssql_linked_servers:
+    #   - name: "DB-2"
+    #     provider: "MSOLEDBSQL"
+    #     data_source: "10.10.10.20"
+    #     remote_user: "domain\\user"
+    #     remote_password: "password"
 
 ## Dependencies
 
@@ -39,28 +82,66 @@ None
 
 ```yaml
 ludus:
-  - vm_name: "{{ range_id }}-MSSQL"
-    hostname: "{{ range_id }}-MSSQL"
-    template: win2019-server-x64-template
-    vlan: 10
-    ip_last_octet: 13
+  - vm_name: "{{ range_id }}-DB-1"
+    hostname: "DB-1"
+    template: win2022-server-x64-template
+    vlan: 30
+    ip_last_octet: 14
     ram_gb: 4
     cpus: 2
     windows:
       sysprep: true
     roles:
       - badsectorlabs.ludus_mssql
+    role_vars:
+      ludus_mssql_version: "2019"
+      ludus_mssql_enable_tcp: true
+      ludus_mssql_mixed_mode_auth: true
+      ludus_mssql_enable_xp_cmdshell: true
+      ludus_mssql_sql_users:
+        - username: "sqladmin"
+          password: "Password123!"
+          sysadmin: true
+        - username: "appuser"
+          password: "Password123!"
+          sysadmin: false
+      ludus_mssql_ad_logins:
+        - username: "domain\\user"
+          sysadmin: false
+        - username: "domain\\user2"
+          sysadmin: true
+      ludus_mssql_impersonations:
+        - grantor: "sqladmin"
+          grantee: "appuser"
+      ludus_mssql_linked_servers:
+        - name: "DB-2"
+          provider: "MSOLEDBSQL"
+          data_source: "10.{{ range_second_octet }}.10.20"
+          remote_user: "domain\\administrator"
+          remote_password: "password"
 ```
 
-## Ludus setup
+## Ludus Setup
 
-```
+```bash
 ludus ansible roles add badsectorlabs.ludus_mssql
 ludus range config get > config.yml
-# Edit config to add the role to the VMs you wish to install MSSQL on and define your desired MSSQL variables (see above)
+# Edit config to add the role to the VMs you wish to install MSSQL on
 ludus range config set -f config.yml
 ludus range deploy -t user-defined-roles
 ```
+
+## Task Execution Order
+
+1. Install MSSQL (skipped if already installed)
+2. Enable mixed mode authentication (if `ludus_mssql_mixed_mode_auth: true`)
+3. Create SQL logins (if `ludus_mssql_sql_users` defined)
+4. Create AD logins (if `ludus_mssql_ad_logins` defined)
+5. Configure impersonations (if `ludus_mssql_impersonations` defined)
+6. Enable TCP and firewall rule (if `ludus_mssql_enable_tcp: true`)
+7. Configure linked servers (if `ludus_mssql_linked_servers` defined)
+8. Enable xp_cmdshell (if `ludus_mssql_enable_xp_cmdshell: true`)
+9. Install SSMS (skipped if already installed)
 
 ## License
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,6 +13,7 @@ ludus_mssql_enable_tcp: false
 ludus_mssql_mixed_mode_auth: true
 ludus_mssql_linked_servers: []
 ludus_mssql_sql_users: []
+ludus_mssql_ad_logins: []
 ludus_mssql_impersonations: []
 ludus_mssql_enable_xp_cmdshell: false
 ludus_mssql_version_map:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,3 +9,10 @@ ludus_mssql_instance_name: MSSQLSERVER
 ludus_mssql_sql_license_key:
 ludus_mssql_ssms_url: "https://aka.ms/ssmsfullsetup"
 ludus_mssql_install_ssms: true
+ludus_mssql_enable_tcp: false
+ludus_mssql_linked_servers: []
+ludus_mssql_version_map:
+  "2019": "15"
+  "2022": "16"
+  "2017": "14"
+  "2016": "13"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,6 +13,7 @@ ludus_mssql_enable_tcp: false
 ludus_mssql_mixed_mode_auth: true
 ludus_mssql_linked_servers: []
 ludus_mssql_sql_users: []
+ludus_mssql_impersonations: []
 ludus_mssql_version_map:
   "2019": "15"
   "2022": "16"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,6 +14,7 @@ ludus_mssql_mixed_mode_auth: true
 ludus_mssql_linked_servers: []
 ludus_mssql_sql_users: []
 ludus_mssql_impersonations: []
+ludus_mssql_enable_xp_cmdshell: false
 ludus_mssql_version_map:
   "2019": "15"
   "2022": "16"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,7 +10,9 @@ ludus_mssql_sql_license_key:
 ludus_mssql_ssms_url: "https://aka.ms/ssmsfullsetup"
 ludus_mssql_install_ssms: true
 ludus_mssql_enable_tcp: false
+ludus_mssql_mixed_mode_auth: true
 ludus_mssql_linked_servers: []
+ludus_mssql_sql_users: []
 ludus_mssql_version_map:
   "2019": "15"
   "2022": "16"

--- a/tasks/create_ad_logins.yml
+++ b/tasks/create_ad_logins.yml
@@ -1,0 +1,33 @@
+---
+- name: "Write AD login creation script"
+  ansible.windows.win_copy:
+    content: |
+      IF NOT EXISTS (SELECT 1 FROM sys.server_principals WHERE name = N'{{ item.username }}')
+      BEGIN
+        CREATE LOGIN [{{ item.username }}] FROM WINDOWS
+          WITH DEFAULT_DATABASE = [master];
+      END
+      {% if item.sysadmin | default(false) %}
+      IF IS_SRVROLEMEMBER('sysadmin', '{{ item.username }}') = 0
+        ALTER SERVER ROLE sysadmin ADD MEMBER [{{ item.username }}];
+      {% else %}
+      IF IS_SRVROLEMEMBER('sysadmin', '{{ item.username }}') = 1
+        ALTER SERVER ROLE sysadmin DROP MEMBER [{{ item.username }}];
+      {% endif %}
+    dest: "C:\\Windows\\Temp\\create_ad_login_{{ item.username | regex_replace('[\\\\/@]', '_') }}.sql"
+  loop: "{{ ludus_mssql_ad_logins }}"
+  when: ludus_mssql_ad_logins | length > 0
+  no_log: false
+
+- name: "Execute AD login creation script"
+  ansible.windows.win_shell: "sqlcmd -S localhost -E -i C:\\Windows\\Temp\\create_ad_login_{{ item.username | regex_replace('[\\\\/@]', '_') }}.sql"
+  loop: "{{ ludus_mssql_ad_logins }}"
+  when: ludus_mssql_ad_logins | length > 0
+  no_log: false
+
+- name: "Remove AD login creation script"
+  ansible.windows.win_file:
+    path: "C:\\Windows\\Temp\\create_ad_login_{{ item.username | regex_replace('[\\\\/@]', '_') }}.sql"
+    state: absent
+  loop: "{{ ludus_mssql_ad_logins }}"
+  when: ludus_mssql_ad_logins | length > 0

--- a/tasks/create_linked_server.yml
+++ b/tasks/create_linked_server.yml
@@ -1,0 +1,14 @@
+---
+- name: "Create linked server"
+  ansible.windows.win_shell: >-
+    sqlcmd -S localhost -E -Q
+    "IF EXISTS (SELECT 1 FROM sys.servers WHERE name = N'{{ item.name }}' AND is_linked = 1)
+    EXEC sp_dropserver '{{ item.name }}', 'droplogins';
+    EXEC master.dbo.sp_addlinkedserver @server = N'{{ item.name }}', @srvproduct = N'', @provider = N'{{ item.provider | default('MSOLEDBSQL') }}', @datasrc = N'{{ item.data_source }}';
+    EXEC master.dbo.sp_addlinkedsrvlogin @rmtsrvname = N'{{ item.name }}', @useself = 'False', @locallogin = NULL, @rmtuser = N'{{ item.remote_user }}', @rmtpassword = N'{{ item.remote_password }}';
+    EXEC master.dbo.sp_serveroption @server = N'{{ item.name }}', @optname = 'rpc out', @optvalue = 'true';
+    EXEC master.dbo.sp_serveroption @server = N'{{ item.name }}', @optname = 'data access', @optvalue = 'true';
+    SELECT name, data_source, provider FROM sys.servers WHERE is_linked = 1;"
+  loop: "{{ ludus_mssql_linked_servers }}"
+  when: ludus_mssql_linked_servers | length > 0
+  no_log: false

--- a/tasks/create_sql_users.yml
+++ b/tasks/create_sql_users.yml
@@ -1,0 +1,40 @@
+---
+- name: "Write SQL user creation script"
+  ansible.windows.win_copy:
+    content: |
+      IF EXISTS (SELECT 1 FROM sys.server_principals WHERE name = N'{{ item.username }}')
+      BEGIN
+        ALTER LOGIN [{{ item.username }}] WITH PASSWORD = N'{{ item.password }}',
+          CHECK_POLICY = OFF,
+          CHECK_EXPIRATION = OFF;
+      END
+      ELSE
+      BEGIN
+        CREATE LOGIN [{{ item.username }}] WITH PASSWORD = N'{{ item.password }}',
+          CHECK_POLICY = OFF,
+          CHECK_EXPIRATION = OFF;
+      END
+      {% if item.sysadmin | default(false) %}
+      IF IS_SRVROLEMEMBER('sysadmin', '{{ item.username }}') = 0
+        ALTER SERVER ROLE sysadmin ADD MEMBER [{{ item.username }}];
+      {% else %}
+      IF IS_SRVROLEMEMBER('sysadmin', '{{ item.username }}') = 1
+        ALTER SERVER ROLE sysadmin DROP MEMBER [{{ item.username }}];
+      {% endif %}
+    dest: "C:\\Windows\\Temp\\create_user_{{ item.username }}.sql"
+  loop: "{{ ludus_mssql_sql_users }}"
+  when: ludus_mssql_sql_users | length > 0
+  no_log: true
+
+- name: "Execute SQL user creation script"
+  ansible.windows.win_shell: "sqlcmd -S localhost -E -i C:\\Windows\\Temp\\create_user_{{ item.username }}.sql"
+  loop: "{{ ludus_mssql_sql_users }}"
+  when: ludus_mssql_sql_users | length > 0
+  no_log: false
+
+- name: "Remove SQL user creation script"
+  ansible.windows.win_file:
+    path: "C:\\Windows\\Temp\\create_user_{{ item.username }}.sql"
+    state: absent
+  loop: "{{ ludus_mssql_sql_users }}"
+  when: ludus_mssql_sql_users | length > 0

--- a/tasks/enable_impersonation.yml
+++ b/tasks/enable_impersonation.yml
@@ -1,0 +1,26 @@
+---
+- name: "Write impersonation grant script"
+  ansible.windows.win_copy:
+    content: |
+      IF EXISTS (SELECT 1 FROM sys.server_principals WHERE name = N'{{ item.grantor }}')
+        AND EXISTS (SELECT 1 FROM sys.server_principals WHERE name = N'{{ item.grantee }}')
+      BEGIN
+        GRANT IMPERSONATE ON LOGIN::[{{ item.grantor }}] TO [{{ item.grantee }}];
+      END
+    dest: "C:\\Windows\\Temp\\impersonate_{{ item.grantor }}_{{ item.grantee }}.sql"
+  loop: "{{ ludus_mssql_impersonations }}"
+  when: ludus_mssql_impersonations | length > 0
+  no_log: false
+
+- name: "Execute impersonation grant script"
+  ansible.windows.win_shell: "sqlcmd -S localhost -E -i C:\\Windows\\Temp\\impersonate_{{ item.grantor }}_{{ item.grantee }}.sql"
+  loop: "{{ ludus_mssql_impersonations }}"
+  when: ludus_mssql_impersonations | length > 0
+  no_log: false
+
+- name: "Remove impersonation grant script"
+  ansible.windows.win_file:
+    path: "C:\\Windows\\Temp\\impersonate_{{ item.grantor }}_{{ item.grantee }}.sql"
+    state: absent
+  loop: "{{ ludus_mssql_impersonations }}"
+  when: ludus_mssql_impersonations | length > 0

--- a/tasks/enable_mixed_mode.yml
+++ b/tasks/enable_mixed_mode.yml
@@ -1,0 +1,12 @@
+---
+- name: Enable SQL Server mixed mode authentication
+  ansible.windows.win_regedit:
+    path: 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\MSSQL{{ ludus_mssql_version_map[ludus_mssql_version] }}.{{ ludus_mssql_instance_name }}\MSSQLServer'
+    name: LoginMode
+    data: 2
+    type: dword
+
+- name: Restart SQL Server service to apply mixed mode auth
+  ansible.windows.win_service:
+    name: "{{ ludus_mssql_instance_name }}"
+    state: restarted

--- a/tasks/enable_tcp.yml
+++ b/tasks/enable_tcp.yml
@@ -1,0 +1,36 @@
+---
+- name: Enable SQL Server TCP protocol via registry
+  ansible.windows.win_regedit:
+    path: 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\MSSQL{{ ludus_mssql_version_map[ludus_mssql_version] }}.MSSQLSERVER\MSSQLServer\SuperSocketNetLib\Tcp'
+    name: Enabled
+    data: 1
+    type: dword
+
+- name: Enable TCP for all IPs via registry
+  ansible.windows.win_regedit:
+    path: 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\MSSQL{{ ludus_mssql_version_map[ludus_mssql_version] }}.MSSQLSERVER\MSSQLServer\SuperSocketNetLib\Tcp\IPAll'
+    name: TcpPort
+    data: "1433"
+    type: string
+
+- name: Clear dynamic ports for IPAll
+  ansible.windows.win_regedit:
+    path: 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\MSSQL{{ ludus_mssql_version_map[ludus_mssql_version] }}.MSSQLSERVER\MSSQLServer\SuperSocketNetLib\Tcp\IPAll'
+    name: TcpDynamicPorts
+    data: ""
+    type: string
+
+- name: Open Windows Firewall for MSSQL TCP 1433
+  community.windows.win_firewall_rule:
+    name: "MSSQL TCP 1433"
+    localport: 1433
+    action: allow
+    direction: in
+    protocol: tcp
+    state: present
+    enabled: true
+
+- name: Restart SQL Server service to apply TCP changes
+  ansible.windows.win_service:
+    name: MSSQLSERVER
+    state: restarteds

--- a/tasks/enable_xp_cmdshell.yml
+++ b/tasks/enable_xp_cmdshell.yml
@@ -1,0 +1,17 @@
+---
+- name: Write xp_cmdshell enable script
+  ansible.windows.win_copy:
+    content: |
+      EXEC sp_configure 'show advanced options', 1;
+      RECONFIGURE;
+      EXEC sp_configure 'xp_cmdshell', 1;
+      RECONFIGURE;
+    dest: "C:\\Windows\\Temp\\enable_xp_cmdshell.sql"
+
+- name: Execute xp_cmdshell enable script
+  ansible.windows.win_shell: "sqlcmd -S localhost -E -i C:\\Windows\\Temp\\enable_xp_cmdshell.sql"
+
+- name: Remove xp_cmdshell enable script
+  ansible.windows.win_file:
+    path: "C:\\Windows\\Temp\\enable_xp_cmdshell.sql"
+    state: absent

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,6 +18,10 @@
   ansible.builtin.include_tasks: create_sql_users.yml
   when: ludus_mssql_sql_users | default([]) | length > 0
 
+- name: Create AD logins
+  ansible.builtin.include_tasks: create_ad_logins.yml
+  when: ludus_mssql_ad_logins | default([]) | length > 0
+
 - name: Configure impersonations
   ansible.builtin.include_tasks: enable_impersonation.yml
   when: ludus_mssql_impersonations | default([]) | length > 0

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,6 +10,14 @@
     file: install-mssql.yml
   when: (not install_check.exists) or (install_check.exists and ludus_mssql_instance_name not in install_check.value)
 
+- name: Enable TCP and firewall for MSSQL
+  ansible.builtin.include_tasks: enable_tcp.yml
+  when: ludus_mssql_enable_tcp | bool
+
+- name: Configure linked servers
+  ansible.builtin.include_tasks: create_linked_server.yml
+  when: ludus_mssql_linked_servers | length > 0
+
 - name: Check if SSMS is already installed
   ansible.windows.win_reg_stat:
     path: 'HKLM:\SOFTWARE\Microsoft\Microsoft SQL Server\160\Tools\ClientSetup'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,6 +18,10 @@
   ansible.builtin.include_tasks: create_sql_users.yml
   when: ludus_mssql_sql_users | length > 0
 
+- name: Configure impersonations
+  ansible.builtin.include_tasks: enable_impersonation.yml
+  when: ludus_mssql_impersonations | length > 0
+
 - name: Enable TCP and firewall for MSSQL
   ansible.builtin.include_tasks: enable_tcp.yml
   when: ludus_mssql_enable_tcp | bool

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,23 +12,27 @@
 
 - name: Enable mixed mode authentication
   ansible.builtin.include_tasks: enable_mixed_mode.yml
-  when: ludus_mssql_mixed_mode_auth | bool
+  when: ludus_mssql_mixed_mode_auth | default(false) | bool
 
 - name: Create SQL users
   ansible.builtin.include_tasks: create_sql_users.yml
-  when: ludus_mssql_sql_users | length > 0
+  when: ludus_mssql_sql_users | default([]) | length > 0
 
 - name: Configure impersonations
   ansible.builtin.include_tasks: enable_impersonation.yml
-  when: ludus_mssql_impersonations | length > 0
+  when: ludus_mssql_impersonations | default([]) | length > 0
 
 - name: Enable TCP and firewall for MSSQL
   ansible.builtin.include_tasks: enable_tcp.yml
-  when: ludus_mssql_enable_tcp | bool
+  when: ludus_mssql_enable_tcp | default(true) | bool
 
 - name: Configure linked servers
   ansible.builtin.include_tasks: create_linked_server.yml
-  when: ludus_mssql_linked_servers | length > 0
+  when: ludus_mssql_linked_servers | default([]) | length > 0
+
+- name: Enable xp_cmdshell
+  ansible.builtin.include_tasks: enable_xp_cmdshell.yml
+  when: ludus_mssql_enable_xp_cmdshell | default(false) | bool
 
 - name: Check if SSMS is already installed
   ansible.windows.win_reg_stat:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,6 +10,14 @@
     file: install-mssql.yml
   when: (not install_check.exists) or (install_check.exists and ludus_mssql_instance_name not in install_check.value)
 
+- name: Enable mixed mode authentication
+  ansible.builtin.include_tasks: enable_mixed_mode.yml
+  when: ludus_mssql_mixed_mode_auth | bool
+
+- name: Create SQL users
+  ansible.builtin.include_tasks: create_sql_users.yml
+  when: ludus_mssql_sql_users | length > 0
+
 - name: Enable TCP and firewall for MSSQL
   ansible.builtin.include_tasks: enable_tcp.yml
   when: ludus_mssql_enable_tcp | bool


### PR DESCRIPTION
This PR extends the ludus_mssql role with several new configurable features useful for lab and attack simulation scenarios.

## New Features

- **TCP enablement** (`ludus_mssql_enable_tcp`, default: `false`)
  Enables the TCP/IP protocol via registry and opens Windows Firewall port 1433. Fixes linked server connectivity issues where SQL Server defaults to Named Pipes only.

- **Mixed mode authentication** (`ludus_mssql_mixed_mode_auth`, default: `false`)
  Enables SQL Server + Windows authentication mode via registry write to the correct `MSSQL<version>.MSSQLSERVER` path and restarts the service.

- **SQL logins** (`ludus_mssql_sql_users`, default: `[]`)
  Creates SQL Server logins with configurable passwords and optional sysadmin role assignment. Idempotent — existing logins are updated via `ALTER LOGIN`. Requires mixed mode auth.

- **Active Directory logins** (`ludus_mssql_ad_logins`, default: `[]`)
  Creates Windows logins from AD accounts using `CREATE LOGIN ... FROM WINDOWS`. Supports optional sysadmin role assignment and removal.

- **Impersonation grants** (`ludus_mssql_impersonations`, default: `[]`)
  Grants `IMPERSONATE ON LOGIN` between two logins. Useful for privilege escalation simulation chains.

- **Linked servers** (`ludus_mssql_linked_servers`, default: `[]`)
  Configures linked servers between MSSQL instances using `MSOLEDBSQL` provider with remote login mapping. Uses `sqlcmd -i` with a temp SQL file to avoid PowerShell module dependencies and shell escaping issues.

- **xp_cmdshell** (`ludus_mssql_enable_xp_cmdshell`, default: `false`)
  Enables `xp_cmdshell` via `sp_configure`. Disabled by default, opt-in only.

## Notes

- All tasks use `sqlcmd -S localhost -E` (Windows auth) for execution — no PowerShell SQL modules required
- Credentials are written to temp `.sql` files and deleted immediately after execution
- All tasks are idempotent and safe to re-run